### PR TITLE
feat: support Apollo Client 3.13.9 internals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-inspector",
-  "version": "1.17.10",
+  "version": "2.0.0",
   "description": "Tool to track apollo client operations",
   "main": "dist/main.js",
   "source": "index.ts",
@@ -24,7 +24,7 @@
     "url": "https://github.com/jpsahoo14/apollo-inspector.git"
   },
   "devDependencies": {
-    "@apollo/client": "3.6.5",
+    "@apollo/client": "3.13.9",
     "@parcel/packager-ts": "^2.8.2",
     "@parcel/transformer-typescript-types": "^2.8.2",
     "@types/lodash-es": "4.17.6",

--- a/src/apollo-client-internals.ts
+++ b/src/apollo-client-internals.ts
@@ -14,6 +14,7 @@ import type {
   CacheWriteBehavior,
   QueryInfo,
 } from "@apollo/client/core/QueryInfo";
+import { canonicalStringify } from "@apollo/client/utilities";
 import { print } from "graphql";
 import type { DocumentNode } from "graphql";
 
@@ -200,7 +201,7 @@ export const hasInFlightLinkObservable = (
   if (typeof inFlightLinkObservables.peek === "function") {
     const entry = inFlightLinkObservables.peek(
       print(serverQuery),
-      JSON.stringify(variables),
+      canonicalStringify(variables),
     );
     return !!entry?.observable;
   }

--- a/src/apollo-client-internals.ts
+++ b/src/apollo-client-internals.ts
@@ -14,7 +14,6 @@ import type {
   CacheWriteBehavior,
   QueryInfo,
 } from "@apollo/client/core/QueryInfo";
-import { canonicalStringify } from "@apollo/client/utilities";
 import { print } from "graphql";
 import type { DocumentNode } from "graphql";
 
@@ -208,6 +207,23 @@ export const hasInFlightLinkObservable = (
 
   return false;
 };
+
+// Mirrors Apollo's `canonicalStringify`: serializes with object keys sorted so
+// that variable objects with the same entries in a different order produce the
+// same in-flight cache key. Implemented locally to avoid an extra dependency on
+// Apollo internals and the associated bundle-size cost.
+const canonicalStringify = (value: unknown) =>
+  JSON.stringify(value, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      return Object.keys(val as Record<string, unknown>)
+        .sort()
+        .reduce<Record<string, unknown>>((sorted, key) => {
+          sorted[key] = (val as Record<string, unknown>)[key];
+          return sorted;
+        }, {});
+    }
+    return val;
+  });
 
 const hasItems = (collection?: CollectionLike | null) => {
   if (!collection) {

--- a/src/apollo-client-internals.ts
+++ b/src/apollo-client-internals.ts
@@ -1,0 +1,255 @@
+import type {
+  ApolloClient,
+  ApolloQueryResult,
+  ErrorPolicy,
+  FetchResult,
+  NormalizedCacheObject,
+  Observable,
+  OperationVariables,
+  WatchQueryFetchPolicy,
+} from "@apollo/client";
+import { isNetworkRequestInFlight } from "@apollo/client/core/networkStatus";
+import type { NetworkStatus } from "@apollo/client/core/networkStatus";
+import type {
+  CacheWriteBehavior,
+  QueryInfo,
+} from "@apollo/client/core/QueryInfo";
+import { print } from "graphql";
+import type { DocumentNode } from "graphql";
+
+type CollectionLike = { size?: number; length?: number };
+
+export type ObservableWithPromise<T = unknown> = Observable<T> & {
+  promise?: Promise<T>;
+};
+
+export type ObservableSubscriptionLike = { unsubscribe: () => void };
+
+export type FetchQueryObservableOptions = {
+  errorPolicy?: ErrorPolicy;
+  fetchPolicy?: WatchQueryFetchPolicy;
+  query: DocumentNode;
+  variables: OperationVariables | undefined;
+};
+
+export type ApolloCacheDiff = {
+  complete?: boolean;
+  missing?: { message?: unknown; path?: unknown }[];
+  result?: unknown;
+};
+
+export type FetchQueryObservableParams = [
+  string,
+  FetchQueryObservableOptions,
+  NetworkStatus?,
+];
+
+export type FetchQueryObservable = (
+  ...args: FetchQueryObservableParams
+) => ObservableWithPromise<ApolloQueryResult<unknown>>;
+
+export type FetchConcastWithInfoParams = [
+  ApolloQueryInfoWithInternals,
+  FetchQueryObservableOptions,
+  NetworkStatus?,
+  DocumentNode?,
+];
+
+export type FetchConcastWithInfoResult = {
+  concast: ObservableWithPromise<ApolloQueryResult<unknown>>;
+  fromLink: boolean;
+};
+
+export type FetchConcastWithInfo = (
+  ...args: FetchConcastWithInfoParams
+) => FetchConcastWithInfoResult;
+
+export type FetchQueryByPolicyParams = [
+  ApolloQueryInfoWithInternals,
+  {
+    fetchPolicy: WatchQueryFetchPolicy;
+    variables: OperationVariables | undefined;
+  },
+];
+
+export type GetObservableFromLinkArgs = [
+  DocumentNode,
+  { queryDeduplication?: boolean },
+  OperationVariables,
+  boolean | Record<string, unknown> | undefined,
+  boolean?,
+];
+
+type TransformedDocumentInfo = {
+  clientQuery?: DocumentNode | null;
+  serverQuery?: DocumentNode | null;
+};
+
+type InFlightLinkObservables =
+  | Map<DocumentNode, Map<string, Observable<FetchResult>>>
+  | {
+      peek?: (...keys: string[]) => { observable?: Observable<FetchResult> };
+    };
+
+export type GetResultsFromLinkArgs = [
+  ApolloQueryInfoWithInternals,
+  CacheWriteBehavior,
+  unknown,
+];
+
+export type ApolloObservableQueryWithInternals = {
+  queryId: string;
+  dirty?: boolean;
+  observers?: CollectionLike;
+  options?: { fetchPolicy?: WatchQueryFetchPolicy };
+  hasObservers?: () => boolean;
+  reportResult: (...args: [any, any]) => void;
+};
+
+export type ApolloQueryInfoWithInternals = Omit<
+  QueryInfo,
+  "document" | "getDiff" | "markResult" | "observableQuery"
+> & {
+  queryId: string;
+  document: DocumentNode | null;
+  dirty?: boolean;
+  getDiff: (variables?: OperationVariables) => ApolloCacheDiff;
+  listeners?: CollectionLike;
+  markResult: (...args: unknown[]) => unknown;
+  observableQuery?: ApolloObservableQueryWithInternals | null;
+  shouldNotify?: () => boolean;
+};
+
+export type ApolloQueryManagerWithInternals = {
+  queries: Map<string, ApolloQueryInfoWithInternals>;
+  getObservableFromLink: (
+    ...args: GetObservableFromLinkArgs
+  ) => Observable<unknown>;
+  inFlightLinkObservables: InFlightLinkObservables;
+  queryDeduplication?: boolean;
+  fetchQueryObservable?: FetchQueryObservable;
+  fetchConcastWithInfo?: FetchConcastWithInfo;
+  getQuery?: (queryId: string) => ApolloQueryInfoWithInternals;
+  getOrCreateQuery?: (queryId: string) => ApolloQueryInfoWithInternals;
+  fetchQueryByPolicy: (...args: FetchQueryByPolicyParams) => unknown;
+  markMutationResult: (...args: unknown[]) => unknown;
+  markMutationOptimistic: (...args: unknown[]) => unknown;
+  defaultOptions: {
+    mutate?: {
+      fetchPolicy: "network-only" | "no-cache";
+    };
+  };
+  broadcastQueries: () => void;
+  getResultsFromLink: (
+    ...args: GetResultsFromLinkArgs
+  ) => Observable<ApolloQueryResult<any>>;
+  getDocumentInfo?: (document: DocumentNode) => TransformedDocumentInfo;
+  transform: (document: DocumentNode) => DocumentNode | TransformedDocumentInfo;
+};
+
+export const getApolloQueryManager = (
+  client: ApolloClient<NormalizedCacheObject>,
+) => {
+  return (
+    client as unknown as { queryManager: ApolloQueryManagerWithInternals }
+  ).queryManager;
+};
+
+export const getQueryInfo = (
+  queryManager: ApolloQueryManagerWithInternals,
+  queryId: string,
+) => {
+  if (typeof queryManager.getOrCreateQuery === "function") {
+    return queryManager.getOrCreateQuery(queryId);
+  }
+
+  if (typeof queryManager.getQuery === "function") {
+    return queryManager.getQuery(queryId);
+  }
+
+  throw new Error("Apollo QueryManager does not expose a query lookup method");
+};
+
+export const getDocumentInfo = (
+  queryManager: ApolloQueryManagerWithInternals,
+  document: DocumentNode,
+) => {
+  if (typeof queryManager.getDocumentInfo === "function") {
+    return queryManager.getDocumentInfo(document);
+  }
+
+  return queryManager.transform(document) as TransformedDocumentInfo;
+};
+
+export const hasInFlightLinkObservable = (
+  queryManager: ApolloQueryManagerWithInternals,
+  serverQuery: DocumentNode | null | undefined,
+  variables: OperationVariables,
+) => {
+  if (!serverQuery) {
+    return false;
+  }
+
+  const inFlightLinkObservables = queryManager.inFlightLinkObservables;
+
+  if (inFlightLinkObservables instanceof Map) {
+    const byVariables = inFlightLinkObservables.get(serverQuery);
+    return !!byVariables?.get(JSON.stringify(variables));
+  }
+
+  if (typeof inFlightLinkObservables.peek === "function") {
+    const entry = inFlightLinkObservables.peek(
+      print(serverQuery),
+      JSON.stringify(variables),
+    );
+    return !!entry?.observable;
+  }
+
+  return false;
+};
+
+const hasItems = (collection?: CollectionLike | null) => {
+  if (!collection) {
+    return false;
+  }
+
+  if (typeof collection.size === "number") {
+    return collection.size > 0;
+  }
+
+  if (typeof collection.length === "number") {
+    return collection.length > 0;
+  }
+
+  return false;
+};
+
+export const shouldNotifyQueryInfo = (
+  queryInfo: ApolloQueryInfoWithInternals,
+) => {
+  if (typeof queryInfo.shouldNotify === "function") {
+    return queryInfo.shouldNotify();
+  }
+
+  const observableQuery = queryInfo.observableQuery;
+  const isDirty =
+    typeof observableQuery?.dirty === "boolean"
+      ? observableQuery.dirty
+      : !!queryInfo.dirty;
+  const hasNotificationTarget =
+    hasItems(queryInfo.listeners) ||
+    (typeof observableQuery?.hasObservers === "function"
+      ? observableQuery.hasObservers()
+      : hasItems(observableQuery?.observers));
+
+  if (!isDirty || !hasNotificationTarget) {
+    return false;
+  }
+
+  if (isNetworkRequestInFlight(queryInfo.networkStatus) && observableQuery) {
+    const fetchPolicy = observableQuery.options?.fetchPolicy;
+    return fetchPolicy === "cache-only" || fetchPolicy === "cache-and-network";
+  }
+
+  return true;
+};

--- a/src/apollo-inspector-utils.ts
+++ b/src/apollo-inspector-utils.ts
@@ -6,12 +6,15 @@ import {
 import {
   IInspectorTrackingConfig,
   IApolloInspectorState,
-  IApolloClient,
   BaseOperation,
   ICache,
   NameNotFound,
 } from "./interfaces";
-import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
+import type { ApolloClient, NormalizedCacheObject } from "@apollo/client";
+import {
+  getApolloQueryManager,
+  shouldNotifyQueryInfo,
+} from "./apollo-client-internals";
 
 export const getOperationName = (query: DocumentNode) => {
   const definition =
@@ -63,11 +66,10 @@ export const resumeOperation = (
 export const getAffectedQueries = (
   client: ApolloClient<NormalizedCacheObject>
 ) => {
-  const watchQueries = (client as unknown as IApolloClient).queryManager
-    .queries;
+  const watchQueries = getApolloQueryManager(client).queries;
   const affectedQueries = [];
   for (const [_key, value] of watchQueries) {
-    if (value.shouldNotify()) {
+    if (value.document && shouldNotifyQueryInfo(value)) {
       affectedQueries.push(value.document);
     }
   }

--- a/src/interfaces/apollo-client.interface.ts
+++ b/src/interfaces/apollo-client.interface.ts
@@ -1,8 +1,6 @@
 import { DocumentNode } from "graphql";
 import {
-  WatchQueryFetchPolicy,
   OperationVariables,
-  Observable,
   FetchResult,
   ErrorPolicy,
   InMemoryCache,
@@ -11,15 +9,24 @@ import {
   InternalRefetchQueriesInclude,
   OnQueryUpdated,
   MutationOptions,
-  ApolloQueryResult,
 } from "@apollo/client";
-import { CacheWriteBehavior, QueryInfo } from "@apollo/client/core/QueryInfo";
+import type {
+  ApolloCacheDiff,
+  ApolloObservableQueryWithInternals,
+  ApolloQueryInfoWithInternals,
+  ApolloQueryManagerWithInternals,
+  FetchConcastWithInfo,
+  FetchConcastWithInfoParams,
+  FetchConcastWithInfoResult,
+  FetchQueryByPolicyParams,
+  FetchQueryObservable,
+  FetchQueryObservableOptions,
+  FetchQueryObservableParams,
+  GetObservableFromLinkArgs,
+  GetResultsFromLinkArgs,
+} from "../apollo-client-internals";
 
-export interface IDiff {
-  result: unknown;
-  missing: IMissing[];
-  complete: boolean;
-}
+export type IDiff = ApolloCacheDiff;
 
 export interface IMissing {
   message: string;
@@ -31,28 +38,9 @@ export interface IApolloClient {
   mutate: () => void;
   watchQuery: () => void;
 }
-export interface IQueryManager {
-  queries: Map<string, IQueryInfo>;
-  getObservableFromLink: (
-    ...args: IGetObservableFromLinkArgs
-  ) => Observable<unknown>;
-  inFlightLinkObservables: Map<
-    DocumentNode,
-    Map<string, Observable<FetchResult>>
-  >;
-  fetchQueryObservable: IFetchQueryObservable;
-  getQuery: (queryId: number) => unknown;
-  fetchQueryByPolicy: (...args: IFetchQueryByPolicy) => unknown;
-  markMutationResult: (...args: IMarkMutationResultArgs) => unknown;
-  markMutationOptimistic: (...args: IMarkMutationOptimisticArgs) => unknown;
-  defaultOptions: IQueryManagerDefaultOptions;
-  broadcastQueries: () => void;
-  getResultsFromLink: (
-    ...args: IGetResultsFromLinkArgs
-  ) => Observable<ApolloQueryResult<any>>;
-}
+export type IQueryManager = ApolloQueryManagerWithInternals;
 
-export type IGetResultsFromLinkArgs = [QueryInfo, CacheWriteBehavior, any];
+export type IGetResultsFromLinkArgs = GetResultsFromLinkArgs;
 
 export type IMarkMutationOptimisticArgs = [unknown, IMutationOperation];
 
@@ -78,11 +66,7 @@ export interface IMutationOperation {
   operationId: number;
 }
 
-export interface IQueryManagerDefaultOptions {
-  mutate?: {
-    fetchPolicy: MutationFetchPolicy;
-  };
-}
+export type IQueryManagerDefaultOptions = IQueryManager["defaultOptions"];
 export type MutationFetchPolicy = Extract<
   FetchPolicy,
   "network-only" | "no-cache"
@@ -98,55 +82,31 @@ export type IMutationResult = IMutationOperation & {
   result: FetchResult<any>;
 };
 
-export type IGetObservableFromLinkArgs = [
-  DocumentNode,
-  { queryDeduplication: boolean },
-  OperationVariables,
-  boolean,
-];
+export type IGetObservableFromLinkArgs = GetObservableFromLinkArgs;
 
-export type IFetchQueryObservable = (
-  ...args: IFetchQueryObservableParams
-) => Observable<unknown>;
+export type IFetchQueryObservable = FetchQueryObservable;
 
-export type IFetchQueryByPolicy = [IQueryInfo, IFetchQueryByPolicyOptions];
+export type IFetchConcastWithInfo = FetchConcastWithInfo;
 
-export type IFetchQueryObservableParams = [
-  number,
-  IFetchQueryObservableOptions,
-];
+export type IFetchConcastWithInfoParams = FetchConcastWithInfoParams;
 
-export interface IFetchQueryByPolicyOptions {
-  fetchPolicy: WatchQueryFetchPolicy;
-  variables: OperationVariables | undefined;
-}
+export type IFetchConcastWithInfoResult = FetchConcastWithInfoResult;
 
-export interface IQueryInfo {
-  observableQuery?: IObservableQuery;
-  getDiff: (variables: OperationVariables | undefined) => IDiff;
-  document: DocumentNode;
-  shouldNotify: () => boolean;
-}
+export type IFetchQueryByPolicy = FetchQueryByPolicyParams;
 
-export interface IObservableQuery {
-  queryId: number;
-  reportResult: (...args: IObservableQueryReportResult) => void;
-}
+export type IFetchQueryObservableParams = FetchQueryObservableParams;
 
-export type IObservableQueryReportResult = [any, any];
+export type IFetchQueryByPolicyOptions = FetchQueryByPolicyParams[1];
 
-export interface IFetchQueryObservableOptions {
-  errorPolicy: ErrorPolicy;
-  fetchPolicy: WatchQueryFetchPolicy;
-  query: DocumentNode;
-  variables: OperationVariables | undefined;
-}
+export type IQueryInfo = ApolloQueryInfoWithInternals;
 
-export interface IQueryInfo {
-  document: DocumentNode;
-  dirty: boolean;
-  markResult: () => void;
-}
+export type IObservableQuery = ApolloObservableQueryWithInternals;
+
+export type IObservableQueryReportResult = Parameters<
+  ApolloObservableQueryWithInternals["reportResult"]
+>;
+
+export type IFetchQueryObservableOptions = FetchQueryObservableOptions;
 
 export interface IApolloClientCache {
   broadcastWatches: (...args: IBroadcastWatches) => void;

--- a/src/recording/record-all-operations.ts
+++ b/src/recording/record-all-operations.ts
@@ -2,20 +2,25 @@ import {
   DataId,
   ISetAllApolloOperations,
   IAllOperations,
-  IApolloClient,
-  IFetchQueryObservableParams,
   IApolloClientObject,
 } from "../interfaces";
 import {
   ApolloClient,
   OperationVariables,
-  Observable,
   NormalizedCacheObject,
   DefaultContext,
   MutationOptions,
   FetchResult,
 } from "@apollo/client";
 import { cloneDeep } from "lodash-es";
+import type { DocumentNode } from "graphql";
+import {
+  getApolloQueryManager,
+  FetchConcastWithInfoParams,
+  FetchQueryObservableParams,
+  ObservableSubscriptionLike,
+  ObservableWithPromise,
+} from "../apollo-client-internals";
 
 type INextParams = [{ data: unknown }];
 
@@ -45,64 +50,117 @@ const trackFetchQueryObservable = (
   let errorCount = 0;
   let completeCount = 0;
   let count = 0;
+  const trackedSubscriptions: ObservableSubscriptionLike[] = [];
+  const queryManager = getApolloQueryManager(client);
 
-  const originalFetchQueryObservable = (client as unknown as IApolloClient)
-    .queryManager.fetchQueryObservable;
-  (client as unknown as IApolloClient).queryManager.fetchQueryObservable =
-    function override(...args: IFetchQueryObservableParams) {
+  const recordOperationStart = (
+    query: DocumentNode,
+    variables: OperationVariables | undefined
+  ) => {
+    const operationCount: number = count + 1;
+    count++;
+    setAllApolloOperations((state: IAllOperations) => {
+      state[operationCount] = {
+        query,
+        variables: variables as OperationVariables,
+        isActive: true,
+        dataId: DataId.ROOT_QUERY,
+      };
+    });
+    return operationCount;
+  };
+
+  const observeOperation = (
+    observable: ObservableWithPromise,
+    operationCount: number
+  ) => {
+    let subscription: ObservableSubscriptionLike | undefined;
+    const unsubscribe = () => {
+      subscription?.unsubscribe();
+      if (subscription) {
+        const index = trackedSubscriptions.indexOf(subscription);
+        if (index >= 0) {
+          trackedSubscriptions.splice(index, 1);
+        }
+      }
+    };
+
+    subscription = observable.subscribe({
+      next: (...args: INextParams) => {
+        nextCount = nextCount + 1;
+        setAllApolloOperations((state: IAllOperations) => {
+          const prev = state[operationCount];
+          state[operationCount] = {
+            ...prev,
+            result: cloneDeep(args && args.length && args[0].data),
+          };
+        });
+      },
+      error: (...args: unknown[]) => {
+        errorCount = errorCount + 1;
+        unsubscribe();
+        setAllApolloOperations((state: IAllOperations) => {
+          const prev = state[operationCount];
+          state[operationCount] = { ...prev, error: cloneDeep(args) };
+        });
+      },
+      complete: (..._args: unknown[]) => {
+        completeCount = completeCount + 1;
+        unsubscribe();
+
+        setAllApolloOperations((state: IAllOperations) => {
+          const prev = state[operationCount];
+          state[operationCount] = { ...prev, isActive: false };
+        });
+      },
+    });
+    trackedSubscriptions.push(subscription);
+  };
+
+  if (typeof queryManager.fetchQueryObservable === "function") {
+    const originalFetchQueryObservable = queryManager.fetchQueryObservable;
+    queryManager.fetchQueryObservable = function override(
+      ...args: FetchQueryObservableParams
+    ) {
       const options = args[1];
       const observable = originalFetchQueryObservable.apply(this, args);
-      const operationCount: number = count + 1;
-      count++;
-      setAllApolloOperations((state: IAllOperations) => {
-        state[operationCount] = {
-          query: options.query,
-          variables: options.variables,
-          isActive: true,
-          dataId: DataId.ROOT_QUERY,
-        };
-      });
+      const operationCount = recordOperationStart(
+        options.query,
+        options.variables
+      );
+      observeOperation(observable as ObservableWithPromise, operationCount);
 
-      const subscription = observable.subscribe({
-        next: (...args: INextParams) => {
-          nextCount = nextCount + 1;
-          setAllApolloOperations((state: IAllOperations) => {
-            const prev = state[operationCount];
-            state[operationCount] = {
-              ...prev,
-              result: cloneDeep(args && args.length && args[0].data),
-            };
-          });
-        },
-        error: (...args: unknown[]) => {
-          errorCount = errorCount + 1;
-          subscription &&
-            subscription.unsubscribe &&
-            subscription.unsubscribe();
-          setAllApolloOperations((state: IAllOperations) => {
-            const prev = state[operationCount];
-            state[operationCount] = { ...prev, error: cloneDeep(args) };
-          });
-        },
-        complete: (..._args: unknown[]) => {
-          completeCount = completeCount + 1;
-          subscription &&
-            subscription.unsubscribe &&
-            subscription.unsubscribe();
-
-          setAllApolloOperations((state: IAllOperations) => {
-            const prev = state[operationCount];
-            state[operationCount] = { ...prev, isActive: false };
-          });
-        },
-      });
-
-      return observable as unknown as Observable<unknown>;
+      return observable;
     };
-  return () => {
-    (client as unknown as IApolloClient).queryManager.fetchQueryObservable =
-      originalFetchQueryObservable;
-  };
+
+    return () => {
+      queryManager.fetchQueryObservable = originalFetchQueryObservable;
+      trackedSubscriptions.forEach((subscription) => subscription.unsubscribe());
+    };
+  }
+
+  if (typeof queryManager.fetchConcastWithInfo === "function") {
+    const originalFetchConcastWithInfo = queryManager.fetchConcastWithInfo;
+    queryManager.fetchConcastWithInfo = function override(
+      ...args: FetchConcastWithInfoParams
+    ) {
+      const [_queryInfo, options, _networkStatus, query] = args;
+      const result = originalFetchConcastWithInfo.apply(this, args);
+      const operationCount = recordOperationStart(
+        query || options.query,
+        options.variables
+      );
+      observeOperation(result.concast, operationCount);
+      return result;
+    };
+
+    return () => {
+      queryManager.fetchConcastWithInfo = originalFetchConcastWithInfo;
+      trackedSubscriptions.forEach((subscription) => subscription.unsubscribe());
+    };
+  }
+
+  return () => {};
 };
 
 const trackClientMutateFn = (

--- a/src/recording/record-verbose-operation/query-info/override-query-info-mark-result.ts
+++ b/src/recording/record-verbose-operation/query-info/override-query-info-mark-result.ts
@@ -4,12 +4,12 @@ import {
   ICachedQueryInfo,
   IApolloInspectorState,
   OperationStage,
-  IApolloClient,
   IQueryInfo,
   QueryOperation,
   IApolloClientObject,
 } from "../../../interfaces";
 import { getAffectedQueries } from "../../../apollo-inspector-utils";
+import { getApolloQueryManager } from "../../../apollo-client-internals";
 
 export const overrideQueryInfoMarkResult = (
   clientObj: IApolloClientObject,
@@ -33,9 +33,8 @@ const overrideForExistingQueries = (
   apolloClient: ApolloClient<NormalizedCacheObject>,
   rawData: IApolloInspectorState
 ) => {
-  const existingWatchQueriesMap: Map<string, IQueryInfo> = (
-    apolloClient as unknown as IApolloClient
-  ).queryManager.queries;
+  const existingWatchQueriesMap: Map<string, IQueryInfo> =
+    getApolloQueryManager(apolloClient).queries;
   const cachedOriginalFns = new Map<string, ICachedQueryInfo>();
 
   for (const [key, value] of existingWatchQueriesMap) {
@@ -83,8 +82,8 @@ const overrideForNewQueries = (
   apolloClient: ApolloClient<NormalizedCacheObject>,
   rawData: IApolloInspectorState
 ) => {
-  const originalWatchQueriesMap = (apolloClient as unknown as IApolloClient)
-    .queryManager.queries;
+  const queryManager = getApolloQueryManager(apolloClient);
+  const originalWatchQueriesMap = queryManager.queries;
   const cachedOriginalFns = new Map<string, ICachedQueryInfo>();
 
   const handler = {
@@ -145,11 +144,10 @@ const overrideForNewQueries = (
   };
 
   const proxy = new Proxy(originalWatchQueriesMap, handler);
-  (apolloClient as unknown as IApolloClient).queryManager.queries = proxy;
+  queryManager.queries = proxy;
 
   return () => {
-    (apolloClient as unknown as IApolloClient).queryManager.queries =
-      originalWatchQueriesMap;
+    queryManager.queries = originalWatchQueriesMap;
     for (const [_key, value] of cachedOriginalFns) {
       const { queryInfo, originalMarkResult } = value;
       queryInfo.markResult = originalMarkResult;

--- a/src/recording/record-verbose-operation/query-manager/override-fetch-query-by-policy.ts
+++ b/src/recording/record-verbose-operation/query-manager/override-fetch-query-by-policy.ts
@@ -2,12 +2,14 @@ import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
 import {
   ISetVerboseApolloOperations,
   IApolloInspectorState,
-  IApolloClient,
-  IFetchQueryByPolicy,
   IVerboseOperationMap,
   QueryOperation,
   IApolloClientObject,
 } from "../../../interfaces";
+import {
+  FetchQueryByPolicyParams,
+  getApolloQueryManager,
+} from "../../../apollo-client-internals";
 
 export const overrideFetchQueryByPolicy = (
   clientObj: IApolloClientObject,
@@ -17,45 +19,45 @@ export const overrideFetchQueryByPolicy = (
   const apolloClient = clientObj.client;
   const map: { [key: string]: boolean } = {};
 
-  const originalFetchQueryByPolicy = (apolloClient as unknown as IApolloClient)
-    .queryManager.fetchQueryByPolicy;
+  const queryManager = getApolloQueryManager(apolloClient);
+  const originalFetchQueryByPolicy = queryManager.fetchQueryByPolicy;
 
-  (apolloClient as unknown as IApolloClient).queryManager.fetchQueryByPolicy =
-    function override(...args: IFetchQueryByPolicy) {
-      const queryInfo = args[0];
-      const options = args[1];
-      const { variables, fetchPolicy } = options;
+  queryManager.fetchQueryByPolicy = function override(
+    ...args: FetchQueryByPolicyParams
+  ) {
+    const queryInfo = args[0];
+    const options = args[1];
+    const { variables, fetchPolicy } = options;
 
-      const operationId = rawData.currentOperationId;
-      rawData.enableDebug &&
-        console.log(
-          `APD operationId:${operationId} fetchQueryByPolicy queryId:${queryInfo.observableQuery?.queryId} fetchPolicy:${fetchPolicy}`
-        );
+    const operationId = rawData.currentOperationId;
+    rawData.enableDebug &&
+      console.log(
+        `APD operationId:${operationId} fetchQueryByPolicy queryId:${queryInfo.observableQuery?.queryId} fetchPolicy:${fetchPolicy}`
+      );
 
-      if (rawData.enableDebug && operationId !== 0 && map[operationId]) {
-        debugger;
-      }
-      map[operationId] = true;
+    if (rawData.enableDebug && operationId !== 0 && map[operationId]) {
+      debugger;
+    }
+    map[operationId] = true;
 
-      const result = originalFetchQueryByPolicy.apply(this, args);
-      const diff = queryInfo.getDiff(variables);
+    const result = originalFetchQueryByPolicy.apply(this, args);
+    const diff = queryInfo.getDiff(variables);
 
-      setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
-        const op = opMap.get(operationId) as QueryOperation | undefined;
-        if (op) {
-          if (rawData.enableDebug && op.fetchPolicy !== fetchPolicy) {
-            debugger;
-          }
-          op.fetchPolicy = fetchPolicy;
-          op.diff = diff;
+    setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
+      const op = opMap.get(operationId) as QueryOperation | undefined;
+      if (op) {
+        if (rawData.enableDebug && op.fetchPolicy !== fetchPolicy) {
+          debugger;
         }
-        return op;
-      });
-      return result;
-    };
+        op.fetchPolicy = fetchPolicy;
+        op.diff = diff;
+      }
+      return op;
+    });
+    return result;
+  };
 
   return () => {
-    (apolloClient as unknown as IApolloClient).queryManager.fetchQueryByPolicy =
-      originalFetchQueryByPolicy;
+    queryManager.fetchQueryByPolicy = originalFetchQueryByPolicy;
   };
 };

--- a/src/recording/record-verbose-operation/query-manager/override-fetch-query-observable.ts
+++ b/src/recording/record-verbose-operation/query-manager/override-fetch-query-observable.ts
@@ -1,79 +1,50 @@
-import {
-  ApolloClient,
-  NormalizedCacheObject,
-  ErrorPolicy,
-  Observable,
-} from "@apollo/client";
-import {} from "../../../apollo-inspector-utils";
+import { ErrorPolicy } from "@apollo/client";
 import {
   ISetVerboseApolloOperations,
   IApolloInspectorState,
-  IApolloClient,
-  IFetchQueryObservableParams,
   QueryOperation,
   IVerboseOperationMap,
   getBaseOperationConstructorExtraParams,
   IApolloClientObject,
 } from "../../../interfaces";
+import {
+  ApolloQueryInfoWithInternals,
+  FetchConcastWithInfoParams,
+  FetchConcastWithInfoResult,
+  FetchQueryObservableOptions,
+  FetchQueryObservableParams,
+  getApolloQueryManager,
+  getQueryInfo,
+  ObservableSubscriptionLike,
+  ObservableWithPromise,
+} from "../../../apollo-client-internals";
 
 export const overrideFetchQueryObservable = (
   clientObj: IApolloClientObject,
   rawData: IApolloInspectorState,
-  setVerboseApolloOperations: ISetVerboseApolloOperations
+  setVerboseApolloOperations: ISetVerboseApolloOperations,
 ) => {
   const apolloClient = clientObj.client;
-  const originalFetchQueryObservable = (
-    apolloClient as unknown as IApolloClient
-  ).queryManager.fetchQueryObservable;
+  const queryManager = getApolloQueryManager(apolloClient);
+  const trackedSubscriptions: ObservableSubscriptionLike[] = [];
 
-  (apolloClient as unknown as IApolloClient).queryManager.fetchQueryObservable =
-    function override(...args: IFetchQueryObservableParams) {
-      const queryId: number = args[0] as number;
+  if (typeof queryManager.fetchQueryObservable === "function") {
+    const originalFetchQueryObservable = queryManager.fetchQueryObservable;
+
+    queryManager.fetchQueryObservable = function override(
+      ...args: FetchQueryObservableParams
+    ) {
+      const queryId = args[0];
       const options = args[1];
-      const { errorPolicy = "none" as ErrorPolicy } = options;
-
-      const fetchPolicy = options.fetchPolicy || "cache-first";
-      const queryInfo = (
-        apolloClient as unknown as IApolloClient
-      ).queryManager.getQuery(queryId);
-
-      const nextOperationId = ++rawData.operationIdCounter;
-      rawData.enableDebug &&
-        console.log(
-          `APD operationId:${nextOperationId} fetchQueryObservable start queryId:${queryId}`
-        );
-      setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
-        const queryOp = new QueryOperation({
-          queryInfo,
-          variables: options.variables,
-          query: options.query,
-          operationId: nextOperationId,
-          fetchPolicy,
-          debuggerEnabled: rawData.enableDebug || false,
-          errorPolicy,
-          ...getBaseOperationConstructorExtraParams({ rawData }, clientObj),
-        });
-        opMap.set(nextOperationId, queryOp);
-        if (
-          rawData.enableDebug &&
-          rawData.queryInfoToOperationId.get(queryInfo)
-        ) {
-          rawData.enableDebug &&
-            console.log(
-              `APD operationId:${
-                rawData.queryInfoToOperationId.get(queryInfo)?.id
-              } currentOperationId:${nextOperationId} queryId:${queryId} `
-            );
-          debugger;
-        }
-        if (
-          rawData.queryInfoToOperationId.has(queryInfo) &&
-          rawData.enableDebug
-        ) {
-          debugger;
-        }
-        rawData.queryInfoToOperationId.set(queryInfo, queryOp);
-        return queryOp;
+      const queryInfo = getQueryInfo(queryManager, queryId);
+      const nextOperationId = recordQueryOperation({
+        clientObj,
+        rawData,
+        setVerboseApolloOperations,
+        queryInfo,
+        options,
+        query: options.query,
+        queryId,
       });
 
       const previousOperationId = rawData.currentOperationId;
@@ -81,86 +52,208 @@ export const overrideFetchQueryObservable = (
       const observable = originalFetchQueryObservable.apply(this, args);
       rawData.currentOperationId = previousOperationId;
 
-      const subscription = observable.subscribe({
-        next: (result: {
-          data: unknown;
-          errors?: unknown;
-          error?: unknown;
-        }) => {
-          rawData.enableDebug &&
-            console.log(
-              `APD operationId:${nextOperationId} fetchQueryObservable next`,
-              result
-            );
-
-          setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
-            const op = opMap.get(nextOperationId) as QueryOperation | undefined;
-            op?.addResult(result.data);
-            op?.addError(result.errors || result.error);
-            rawData.broadcastQueriesOperationId = nextOperationId;
-            return op;
-          });
-        },
-        error: (error: unknown) => {
-          rawData.enableDebug &&
-            console.log(
-              `APD operationId:${nextOperationId} fetchQueryObservable error`
-            );
-
-          setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
-            const op = opMap.get(nextOperationId);
-            op?.addError(error);
-            return op;
-          });
-          subscription.unsubscribe();
-        },
-        complete: () => {
-          rawData.enableDebug &&
-            console.log(
-              `APD operationId:${nextOperationId} fetchQueryObservable complete`
-            );
-
-          subscription && subscription.unsubscribe();
-          setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
-            const op = opMap.get(nextOperationId);
-            op?.setInActive();
-            return op;
-          });
-        },
+      trackObservableResult({
+        observable: observable as ObservableWithPromise,
+        operationId: nextOperationId,
+        rawData,
+        setVerboseApolloOperations,
+        trackedSubscriptions,
       });
 
-      (observable.promise as Promise<unknown>)
-        .then((result: unknown) => {
-          rawData.enableDebug &&
-            console.log(
-              `APD operationId:${nextOperationId} fetchQueryObservable then`,
-              result
-            );
-
-          setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
-            const op = opMap.get(nextOperationId);
-            op && (op.duration.operationExecutionEndTime = performance.now());
-            return op;
-          });
-        })
-        .catch(() => {
-          rawData.enableDebug &&
-            console.log(
-              `APD operationId:${nextOperationId} fetchQueryObservable catch`
-            );
-
-          setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
-            const op = opMap.get(nextOperationId);
-            op && (op.duration.operationExecutionEndTime = performance.now());
-            return op;
-          });
-        });
-      return observable as unknown as Observable<unknown>;
+      return observable;
     };
 
-  return () => {
-    (
-      apolloClient as unknown as IApolloClient
-    ).queryManager.fetchQueryObservable = originalFetchQueryObservable;
+    return () => {
+      queryManager.fetchQueryObservable = originalFetchQueryObservable;
+      trackedSubscriptions.forEach((subscription) =>
+        subscription.unsubscribe(),
+      );
+    };
+  }
+
+  if (typeof queryManager.fetchConcastWithInfo === "function") {
+    const originalFetchConcastWithInfo = queryManager.fetchConcastWithInfo;
+
+    queryManager.fetchConcastWithInfo = function override(
+      ...args: FetchConcastWithInfoParams
+    ): FetchConcastWithInfoResult {
+      const [queryInfo, options, _networkStatus, query] = args;
+      const nextOperationId = recordQueryOperation({
+        clientObj,
+        rawData,
+        setVerboseApolloOperations,
+        queryInfo,
+        options,
+        query: query || options.query,
+        queryId: queryInfo.queryId,
+      });
+
+      const previousOperationId = rawData.currentOperationId;
+      rawData.currentOperationId = nextOperationId;
+      const result = originalFetchConcastWithInfo.apply(this, args);
+      rawData.currentOperationId = previousOperationId;
+
+      trackObservableResult({
+        observable: result.concast,
+        operationId: nextOperationId,
+        rawData,
+        setVerboseApolloOperations,
+        trackedSubscriptions,
+      });
+
+      return result;
+    };
+
+    return () => {
+      queryManager.fetchConcastWithInfo = originalFetchConcastWithInfo;
+      trackedSubscriptions.forEach((subscription) =>
+        subscription.unsubscribe(),
+      );
+    };
+  }
+
+  return () => {};
+};
+
+const recordQueryOperation = ({
+  clientObj,
+  rawData,
+  setVerboseApolloOperations,
+  queryInfo,
+  options,
+  query,
+  queryId,
+}: {
+  clientObj: IApolloClientObject;
+  rawData: IApolloInspectorState;
+  setVerboseApolloOperations: ISetVerboseApolloOperations;
+  queryInfo: ApolloQueryInfoWithInternals;
+  options: FetchQueryObservableOptions;
+  query: FetchQueryObservableOptions["query"];
+  queryId: unknown;
+}) => {
+  const { errorPolicy = "none" as ErrorPolicy } = options;
+  const fetchPolicy = options.fetchPolicy || "cache-first";
+  const nextOperationId = ++rawData.operationIdCounter;
+
+  rawData.enableDebug &&
+    console.log(
+      `APD operationId:${nextOperationId} fetchQuery start queryId:${queryId}`,
+    );
+
+  setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
+    const queryOp = new QueryOperation({
+      queryInfo,
+      variables: options.variables,
+      query,
+      operationId: nextOperationId,
+      fetchPolicy,
+      debuggerEnabled: rawData.enableDebug || false,
+      errorPolicy,
+      ...getBaseOperationConstructorExtraParams({ rawData }, clientObj),
+    });
+    opMap.set(nextOperationId, queryOp);
+    if (rawData.enableDebug && rawData.queryInfoToOperationId.get(queryInfo)) {
+      rawData.enableDebug &&
+        console.log(
+          `APD operationId:${
+            rawData.queryInfoToOperationId.get(queryInfo)?.id
+          } currentOperationId:${nextOperationId} queryId:${queryId} `,
+        );
+      debugger;
+    }
+    if (rawData.queryInfoToOperationId.has(queryInfo) && rawData.enableDebug) {
+      debugger;
+    }
+    rawData.queryInfoToOperationId.set(queryInfo, queryOp);
+    return queryOp;
+  });
+
+  return nextOperationId;
+};
+
+const trackObservableResult = ({
+  observable,
+  operationId,
+  rawData,
+  setVerboseApolloOperations,
+  trackedSubscriptions,
+}: {
+  observable: ObservableWithPromise;
+  operationId: number;
+  rawData: IApolloInspectorState;
+  setVerboseApolloOperations: ISetVerboseApolloOperations;
+  trackedSubscriptions: ObservableSubscriptionLike[];
+}) => {
+  let subscription: ObservableSubscriptionLike | undefined;
+
+  const unsubscribe = () => {
+    subscription?.unsubscribe();
+    if (subscription) {
+      const index = trackedSubscriptions.indexOf(subscription);
+      if (index >= 0) {
+        trackedSubscriptions.splice(index, 1);
+      }
+    }
   };
+
+  subscription = observable.subscribe({
+    next: (result: { data: unknown; errors?: unknown; error?: unknown }) => {
+      rawData.enableDebug &&
+        console.log(`APD operationId:${operationId} fetchQuery next`, result);
+
+      setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
+        const op = opMap.get(operationId) as QueryOperation | undefined;
+        op?.addResult(result.data);
+        op?.addError(result.errors || result.error);
+        rawData.broadcastQueriesOperationId = operationId;
+        return op;
+      });
+    },
+    error: (error: unknown) => {
+      rawData.enableDebug &&
+        console.log(`APD operationId:${operationId} fetchQuery error`);
+
+      setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
+        const op = opMap.get(operationId);
+        op?.addError(error);
+        return op;
+      });
+      unsubscribe();
+    },
+    complete: () => {
+      rawData.enableDebug &&
+        console.log(`APD operationId:${operationId} fetchQuery complete`);
+
+      unsubscribe();
+      setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
+        const op = opMap.get(operationId);
+        op?.setInActive();
+        return op;
+      });
+    },
+  });
+  trackedSubscriptions.push(subscription);
+
+  observable.promise
+    ?.then((result: unknown) => {
+      rawData.enableDebug &&
+        console.log(`APD operationId:${operationId} fetchQuery then`, result);
+
+      setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
+        const op = opMap.get(operationId);
+        op && (op.duration.operationExecutionEndTime = performance.now());
+        return op;
+      });
+    })
+    .catch(() => {
+      rawData.enableDebug &&
+        console.log(`APD operationId:${operationId} fetchQuery catch`);
+
+      setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
+        const op = opMap.get(operationId);
+        op && (op.duration.operationExecutionEndTime = performance.now());
+        return op;
+      });
+    });
 };

--- a/src/recording/record-verbose-operation/query-manager/override-get-observable-from-link.ts
+++ b/src/recording/record-verbose-operation/query-manager/override-get-observable-from-link.ts
@@ -1,21 +1,20 @@
 import {
-  ApolloClient,
-  DocumentNode,
-  NormalizedCacheObject,
   Observable,
-  OperationVariables,
   Observer,
 } from "@apollo/client";
 import {
   ISetVerboseApolloOperations,
   IApolloInspectorState,
-  IApolloClient,
-  IQueryManager,
   QueryOperation,
   IVerboseOperationMap,
-  IGetObservableFromLinkArgs,
   IApolloClientObject,
 } from "../../../interfaces";
+import {
+  GetObservableFromLinkArgs,
+  getApolloQueryManager,
+  getDocumentInfo,
+  hasInFlightLinkObservable,
+} from "../../../apollo-client-internals";
 
 interface IError {
   operationId: number;
@@ -44,48 +43,49 @@ export const overrideGetObservableFromLink = (
   const apolloClient = clientObj.client;
   const map: { [key: string]: boolean } = {};
 
-  const originalGetObservableFromLink = (
-    apolloClient as unknown as IApolloClient
-  ).queryManager.getObservableFromLink;
+  const queryManager = getApolloQueryManager(apolloClient);
+  const originalGetObservableFromLink = queryManager.getObservableFromLink;
 
-  (
-    apolloClient as unknown as IApolloClient
-  ).queryManager.getObservableFromLink = function override(
-    ...args: IGetObservableFromLinkArgs
+  queryManager.getObservableFromLink = function override(
+    ...args: GetObservableFromLinkArgs
   ) {
-    const [query, context, variables, deduplicationValue] = args;
+    const [
+      query,
+      context,
+      variables,
+      extensionsOrDeduplication,
+      deduplicationValue
+    ] = args;
 
     const deduplication =
-      (deduplicationValue || context?.queryDeduplication) ??
+      (typeof deduplicationValue === "boolean"
+        ? deduplicationValue
+        : typeof extensionsOrDeduplication === "boolean"
+        ? extensionsOrDeduplication
+        : context?.queryDeduplication) ??
       this.queryDeduplication;
 
     const operationId = rawData.currentOperationId;
     debug(rawData, operationId, map);
 
-    const {
-      serverQuery,
-      clientQuery,
-    }: {
-      serverQuery: DocumentNode | undefined;
-      clientQuery: DocumentNode | undefined;
-    } = this.transform(query);
+    const { serverQuery, clientQuery } = getDocumentInfo(this, query);
 
     rawData.enableDebug &&
       console.log(
         `APD operationId:${operationId} getObservableFromLink serverQuery:${!!serverQuery} clientQuery:${!!clientQuery}`
       );
 
-    const piggyBackOnExistingObservable = hasPiggyBackOnExistingObservable({
-      queryManager: this,
+    const piggyBackOnExistingObservable = hasInFlightLinkObservable(
+      this,
       serverQuery,
-      variables,
-    });
+      variables
+    );
 
     setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
       const op = opMap.get(operationId) as QueryOperation | undefined;
       if (op) {
-        op.serverQuery = serverQuery;
-        op.clientQuery = clientQuery;
+        op.serverQuery = serverQuery || undefined;
+        op.clientQuery = clientQuery || undefined;
         op.deduplication = deduplication;
         op.piggyBackOnExistingObservable = piggyBackOnExistingObservable;
       }
@@ -137,36 +137,10 @@ export const overrideGetObservableFromLink = (
   };
 
   return () => {
-    (
-      apolloClient as unknown as IApolloClient
-    ).queryManager.getObservableFromLink = originalGetObservableFromLink;
+    queryManager.getObservableFromLink = originalGetObservableFromLink;
   };
 };
 
-interface IPiggyBackOnExistingObservable {
-  queryManager: IQueryManager;
-  serverQuery: DocumentNode | undefined;
-  variables: OperationVariables;
-}
-
-const hasPiggyBackOnExistingObservable = ({
-  queryManager,
-  serverQuery,
-  variables,
-}: IPiggyBackOnExistingObservable): boolean => {
-  if (serverQuery) {
-    const byVariables = queryManager.inFlightLinkObservables.get(serverQuery);
-    if (byVariables) {
-      const varJson = JSON.stringify(variables);
-      const observable = byVariables.get(varJson);
-      if (observable) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-};
 function debug(
   rawDataRef: IApolloInspectorState,
   operationId: number,

--- a/src/recording/record-verbose-operation/query-manager/override-get-results-from-link.ts
+++ b/src/recording/record-verbose-operation/query-manager/override-get-results-from-link.ts
@@ -1,21 +1,15 @@
-import {
-  NormalizedCacheObject,
-  ErrorPolicy,
-  Observable,
-  ApolloClient,
-} from "@apollo/client";
 import { getAffectedQueries } from "../../../apollo-inspector-utils";
 import {
   ISetVerboseApolloOperations,
   IApolloInspectorState,
-  IApolloClient,
-  IFetchQueryObservableParams,
   QueryOperation,
   IVerboseOperationMap,
-  getBaseOperationConstructorExtraParams,
-  IGetResultsFromLinkArgs,
   IApolloClientObject,
 } from "../../../interfaces";
+import {
+  getApolloQueryManager,
+  GetResultsFromLinkArgs,
+} from "../../../apollo-client-internals";
 
 export const overrideGetResultsFromLink = (
   clientObj: IApolloClientObject,
@@ -23,40 +17,40 @@ export const overrideGetResultsFromLink = (
   setVerboseApolloOperations: ISetVerboseApolloOperations
 ) => {
   const apolloClient = clientObj.client;
-  const originalgetResultsFromLink = (apolloClient as unknown as IApolloClient)
-    .queryManager.getResultsFromLink;
+  const queryManager = getApolloQueryManager(apolloClient);
+  const originalGetResultsFromLink = queryManager.getResultsFromLink;
   const cleanUps: (() => void)[] = [];
-  (apolloClient as unknown as IApolloClient).queryManager.getResultsFromLink =
-    function override(...args: IGetResultsFromLinkArgs) {
-      const operationId = rawData.currentOperationId;
 
-      const observable = originalgetResultsFromLink.apply(this, args);
+  queryManager.getResultsFromLink = function override(
+    ...args: GetResultsFromLinkArgs
+  ) {
+    const operationId = rawData.currentOperationId;
+    const observable = originalGetResultsFromLink.apply(this, args);
 
-      const subscription = observable.subscribe({
-        next: () => {
-          setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
-            const operation = opMap.get(operationId);
-            const affectedQueries = getAffectedQueries(apolloClient);
-            operation?.addAffectedQueries(affectedQueries);
-            return operation;
-          });
-        },
-        error: () => {
-          subscription.unsubscribe();
-        },
-        complete: () => {
-          subscription.unsubscribe();
-        },
-      });
+    const subscription = observable.subscribe({
+      next: () => {
+        setVerboseApolloOperations((opMap: IVerboseOperationMap) => {
+          const operation = opMap.get(operationId) as QueryOperation | undefined;
+          const affectedQueries = getAffectedQueries(apolloClient);
+          operation?.addAffectedQueries(affectedQueries);
+          return operation;
+        });
+      },
+      error: () => {
+        subscription.unsubscribe();
+      },
+      complete: () => {
+        subscription.unsubscribe();
+      },
+    });
 
-      cleanUps.push(() => subscription.unsubscribe());
+    cleanUps.push(() => subscription.unsubscribe());
 
-      return observable;
-    };
+    return observable;
+  };
 
   return () => {
-    (apolloClient as unknown as IApolloClient).queryManager.getResultsFromLink =
-      originalgetResultsFromLink;
+    queryManager.getResultsFromLink = originalGetResultsFromLink;
     cleanUps.forEach((cleanup) => cleanup());
   };
 };

--- a/src/recording/record-verbose-operation/record-verbose-operations-utils.ts
+++ b/src/recording/record-verbose-operation/record-verbose-operations-utils.ts
@@ -8,6 +8,7 @@ import {
   getBaseOperationConstructorExtraParams,
   IApolloClientObject,
 } from "../../interfaces";
+import { shouldNotifyQueryInfo } from "../../apollo-client-internals";
 
 export const addAffectedWatchQueriesAsRelatedOperations = (
   clientObj: IApolloClientObject,
@@ -20,7 +21,8 @@ export const addAffectedWatchQueriesAsRelatedOperations = (
     .queryManager.queries;
 
   for (const [_key, value] of watchQueries) {
-    if (value.shouldNotify()) {
+    const document = value.document;
+    if (document && shouldNotifyQueryInfo(value)) {
       const observableQuery = value.observableQuery;
       if (observableQuery) {
         const originalReportResult = observableQuery.reportResult;
@@ -42,7 +44,7 @@ export const addAffectedWatchQueriesAsRelatedOperations = (
             const queryOp = new QueryOperation({
               queryInfo: value,
               variables,
-              query: value.document,
+              query: document,
               operationId: nextOperationId,
               fetchPolicy: "cache-only",
               debuggerEnabled: rawData.enableDebug || false,

--- a/src/recording/record-verbose-operation/record-verbose-operations-utils.ts
+++ b/src/recording/record-verbose-operation/record-verbose-operations-utils.ts
@@ -1,14 +1,16 @@
 import {
   ISetVerboseApolloOperations,
   IApolloInspectorState,
-  IApolloClient,
   IVerboseOperationMap,
   IObservableQueryReportResult,
   QueryOperation,
   getBaseOperationConstructorExtraParams,
   IApolloClientObject,
 } from "../../interfaces";
-import { shouldNotifyQueryInfo } from "../../apollo-client-internals";
+import {
+  getApolloQueryManager,
+  shouldNotifyQueryInfo,
+} from "../../apollo-client-internals";
 
 export const addAffectedWatchQueriesAsRelatedOperations = (
   clientObj: IApolloClientObject,
@@ -17,8 +19,7 @@ export const addAffectedWatchQueriesAsRelatedOperations = (
   operationId: number,
   cleanUps: (() => void)[]
 ) => {
-  const watchQueries = (clientObj.client as unknown as IApolloClient)
-    .queryManager.queries;
+  const watchQueries = getApolloQueryManager(clientObj.client).queries;
 
   for (const [_key, value] of watchQueries) {
     const document = value.document;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,19 +2,20 @@
 # yarn lockfile v1
 
 
-"@apollo/client@3.6.5":
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.5.tgz#6a7baaf05852187b0eac1c6064e721d47326d70c"
-  integrity sha512-xGAZzv1f5abyH45MSU5eOLyGQuP4Ps0OhP36pSCtt6pCICI3n4yDkdftFCPvqDVqVTuciX1kkyeJPfGodz5kwg==
+"@apollo/client@3.13.9":
+  version "3.13.9"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.13.9.tgz#311e0df1734aaa5598e01a292bb7982df49cc062"
+  integrity sha512-RStSzQfL1XwL6/NWd7W8avhGQYTgPCtJ+qHkkTTSj9Upp3VVm6Oppv81YWdXG1FgEpDPW4hvCrTUELdcC4inCQ==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
-    "@wry/context" "^0.6.0"
-    "@wry/equality" "^0.5.0"
-    "@wry/trie" "^0.3.0"
+    "@wry/caches" "^1.0.0"
+    "@wry/equality" "^0.5.6"
+    "@wry/trie" "^0.5.0"
     graphql-tag "^2.12.6"
     hoist-non-react-statics "^3.3.2"
-    optimism "^0.16.1"
+    optimism "^0.18.0"
     prop-types "^15.7.2"
+    rehackt "^0.1.0"
     symbol-observable "^4.0.0"
     ts-invariant "^0.10.3"
     tslib "^2.3.0"
@@ -953,10 +954,10 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
-"@wry/context@^0.6.0":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.1.tgz#c3c29c0ad622adb00f6a53303c4f965ee06ebeb2"
-  integrity sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==
+"@wry/caches@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wry/caches/-/caches-1.0.1.tgz#8641fd3b6e09230b86ce8b93558d44cf1ece7e52"
+  integrity sha512-bXuaUNLVVkD20wcGBWRyo7j9N3TxePEWFZj2Y+r9OoUzfqmavM84+mFykRicNsBqatba5JLay1t48wxaXaWnlA==
   dependencies:
     tslib "^2.3.0"
 
@@ -967,17 +968,17 @@
   dependencies:
     tslib "^2.3.0"
 
-"@wry/equality@^0.5.0":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.3.tgz#fafebc69561aa2d40340da89fa7dc4b1f6fb7831"
-  integrity sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==
+"@wry/equality@^0.5.6":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.7.tgz#72ec1a73760943d439d56b7b1e9985aec5d497bb"
+  integrity sha512-BRFORjsTuQv5gxcXsuDXx6oGRhuVsEGwZy6LOzRRfgu+eSfxbhUQ9L9YtSEIuIjY/o7g3iWFjrc5eSY1GXP2Dw==
   dependencies:
     tslib "^2.3.0"
 
-"@wry/trie@^0.3.0":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.2.tgz#a06f235dc184bd26396ba456711f69f8c35097e6"
-  integrity sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==
+"@wry/trie@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.5.0.tgz#11e783f3a53f6e4cd1d42d2d1323f5bc3fa99c94"
+  integrity sha512-FNoYzHawTMk/6KMQoEG5O4PuioX19UbwdQKF44yw0nLfOypfQdjtfZzo/UIJWAJ23sNIFbD1Ug9lbaDGMwbqQA==
   dependencies:
     tslib "^2.3.0"
 
@@ -1728,13 +1729,15 @@ object-sizeof@^2.6.1:
   dependencies:
     buffer "^6.0.3"
 
-optimism@^0.16.1:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.2.tgz#519b0c78b3b30954baed0defe5143de7776bf081"
-  integrity sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==
+optimism@^0.18.0:
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.18.1.tgz#5cf16847921413dbb0ac809907370388b9c6335f"
+  integrity sha512-mLXNwWPa9dgFyDqkNi54sjDyNJ9/fTI6WGBLgnXku1vdKY/jovHfZT5r+aiVeFFLOz+foPNOm5YJ4mqgld2GBQ==
   dependencies:
+    "@wry/caches" "^1.0.0"
     "@wry/context" "^0.7.0"
-    "@wry/trie" "^0.3.0"
+    "@wry/trie" "^0.5.0"
+    tslib "^2.3.0"
 
 ordered-binary@^1.2.4:
   version "1.4.0"
@@ -1874,6 +1877,11 @@ regenerator-runtime@^0.13.7:
   version "0.13.11"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
   integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
+
+rehackt@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/rehackt/-/rehackt-0.1.0.tgz#a7c5e289c87345f70da8728a7eb878e5d03c696b"
+  integrity sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==
 
 resolve-from@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Summary
- upgrade dev Apollo dependency to @apollo/client 3.13.9
- add a compatibility layer for Apollo QueryManager/QueryInfo internals used by the inspector
- update operation recording and verbose query-manager hooks to work with Apollo internals in 3.13.x

## Details
- introduced src/apollo-client-internals.ts to normalize access to internal APIs (getOrCreateQuery, fetchConcastWithInfo, in-flight link observables, and query notification checks)
- replaced direct internal casts in utility and recording code with compatibility helpers
- updated internal interface aliases to reflect Apollo internals shape
- adjusted operation tracking to support both fetchQueryObservable and fetchConcastWithInfo

## Validation
- yarn build completes successfully

## Context
These changes are needed so apollo-inspector can keep working for consumers using Apollo Client 3.13.9, including graphitation/packages/rempl-apollo-devtools.